### PR TITLE
Show all associated files in quick pick

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -21,8 +21,8 @@ export async function listAssociated(uri: vscode.Uri | undefined) {
 
     const targetPaths = targets
         .map(t => getTargetPaths(sourcePath, association, t)
-            .find(p => fs.existsSync(p)))
-        .filter(t => !!t) as string[];
+            .filter(p => fs.existsSync(p)))
+        .reduce((a, b) => a.concat(b)) as string[];
 
     if (targetPaths.length === 0) {
         vscode.window.showWarningMessage('Unable to find matching files.');


### PR DESCRIPTION
I would like to be able to show multiple finds in the associated extensions. This is common in a project I'm working on:
![image](https://user-images.githubusercontent.com/954102/115966412-d01d5400-a503-11eb-9e6b-ba40378f61b5.png)

Even though I have this configured:
```json
  "switcher.associations": [
    {
      "extension": ".selectors.ts",
      "associated": {
        "custom": [
          ".actions.ts",
          ".effects.ts",
          ".reducer.ts",
          ".types.ts",
        ]
      }
    }
  ]
```

The extension always shows only the first find, so it only shows me `feature1.actions.ts`:
![image](https://user-images.githubusercontent.com/954102/115966463-078c0080-a504-11eb-896d-c47828a7e20d.png)

With the proposed change, it will show all the associated files in the quick pick, so I can choose the one I want:
![image](https://user-images.githubusercontent.com/954102/115966494-29858300-a504-11eb-9bae-149a7c199b73.png)

I don't see this as much of a breaking change, but of course, I would like to hear what you think, this would enable any association rule to show all the associations instead of just the first one.